### PR TITLE
Get dimensions from the image, rather than it's calculated ones

### DIFF
--- a/lib/js/modules/z.thumbviewer.js
+++ b/lib/js/modules/z.thumbviewer.js
@@ -3,9 +3,9 @@
 
 Adapted z.imageviewer.js to be able to work with tablets and
 phones.
- 
+
 http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,9 @@ limitations under the License.
 
 ---------------------------------------------------------- */
 
-$.widget("ui.thumbviewer", 
+$.widget("ui.thumbviewer",
 {
-    _init: function() { 
+    _init: function() {
         let image = this.element;
 
         /* Defer the init to when the image is loaded */
@@ -26,7 +26,7 @@ $.widget("ui.thumbviewer",
             $(image[0]).on("load", this.init.bind(this));
         }
     },
-	
+
     init: function() {
         var image = this.element;
         var loadImageFun = this.loadImage.bind(this);
@@ -41,7 +41,7 @@ $.widget("ui.thumbviewer",
         this.loader = null;
         this.overlay = null;
     },
-	
+
     loadImage: function() {
         var ui = this;
 
@@ -60,7 +60,7 @@ $.widget("ui.thumbviewer",
         if(bigImg.hasClass("loaded-bigImage")) {
             ui.showBig();
             return;
-        } 
+        }
 
         this.loader = $('<div></div>')
             .css({
@@ -91,11 +91,13 @@ $.widget("ui.thumbviewer",
 
     setWidthHeight: function() {
         this.bigImg.attr({
-            width: $(this.bigImg, this.element.parent()).width(),
-            height: $(this.bigImg, this.element.parent()).height() 
+            // get the original image dimensions,
+            // rather than the calculated ones
+            width: $(this.bigImg, this.element.parent())[0].width,
+            height: $(this.bigImg, this.element.parent())[0].height
         });
     },
-	
+
     showBig: function() {
         var ui = this;
 
@@ -111,7 +113,7 @@ $.widget("ui.thumbviewer",
             fullWidth = $(window).width() - 40;
             fullHeight = zoomImgHeight * (fullWidth / zoomImgWidth);
         }
-		
+
         if(zoomImgHeight > $(window).height()) {
             fullHeight = $(window).height() - 40;
             fullWidth = zoomImgWidth * (fullHeight / zoomImgHeight);


### PR DESCRIPTION
## Changes
- ensure the original image's dimensions are used when calculating size

## Linked Issues
- https://github.com/channelme/channelwww/issues/254